### PR TITLE
Set position and size of the window

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,9 +15,15 @@ const tcpevents = new TcpEventEmitter()
 // run in development mode?
 const isDevMode = false
 
+// Get the current window
+var win = nw.Window.get();
+if (win.x < 500){ //if it's on the left of the screen already, move and resize it
+    win.moveTo(0, 0)
+    win.resizeTo(500, 700)
+}
+
+// if Development mode, then show the debug tools
 if(isDevMode){
-    // Get the current window
-    var win = nw.Window.get();
     // Open the Dev Tools every time (used for debugging only), it defaults to the console which is what we need
     win.showDevTools()
 }


### PR DESCRIPTION
If the window is already on the left side of the screen, then set the position to 0, 0 and the size to 500, 700

This will not resize or move the window if the user has put/snapped the window on the right hand side of the screen `Win + → `